### PR TITLE
feat: implementar template y envío de correo de verificación

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -18,12 +18,14 @@
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
-        "morgan": "^1.10.1"
+        "morgan": "^1.10.1",
+        "nodemailer": "^7.0.9"
     },
     "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/morgan": "^1.9.10",
+        "@types/nodemailer": "^7.0.2",
         "nodemon": "^3.1.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"

--- a/apps/auth/src/controllers/auth.ts
+++ b/apps/auth/src/controllers/auth.ts
@@ -8,6 +8,9 @@ import {
     generateAuthToken,
     hashPassword,
 } from "@repo/utils"
+import jwt from "jsonwebtoken"
+import { sendEmail } from "../utils/sendEmail"
+import { emailTemplate } from "../utils/templates/emailVerificationTemplate"
 
 type Variation = "user" | "giver" | "shelter"
 
@@ -79,7 +82,14 @@ export const register = async (
         description: user.description ?? null,
     }
 
-    // TODO: envio de correos a usuarios, según rol
+    const token = jwt.sign({ id: user.email }, process.env.JWT_SECRET!, { expiresIn: "1h" })
+    const verificationLink = `${process.env.FRONTEND_URL}/verify-email?token=${token}`
+
+    await sendEmail({
+        to: user.email,
+        subject: "Verifica tu cuenta en Ayün Pet 🐾",
+        html: emailTemplate(verificationLink),
+    })
 
     const { error: insertError } = await supabase.from("users").insert([payload])
 

--- a/apps/auth/src/routes/auth.ts
+++ b/apps/auth/src/routes/auth.ts
@@ -1,10 +1,15 @@
 import { Router } from "express"
+import { sendEmail } from "../utils/sendEmail"
+import { emailTemplate } from "../utils/templates/emailVerificationTemplate"
 import { login, register } from "../controllers/auth"
 
 const router = Router()
 
 router.post("/login", login)
-
 router.post("/register/:variation", register)
+
+// Ruta de prueba de correo
+// router.get("/test-email", async (req, res) => {
+//})
 
 export default router

--- a/apps/auth/src/utils/sendEmail.ts
+++ b/apps/auth/src/utils/sendEmail.ts
@@ -1,0 +1,24 @@
+import nodemailer from "nodemailer";
+
+interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export const sendEmail = async ({ to, subject, html }: EmailOptions) => {
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.MAIL_USER,
+      pass: process.env.MAIL_PASS,
+    },
+  });
+
+  await transporter.sendMail({
+    from: `"Ayün Pet 🐾" <${process.env.MAIL_USER}>`,
+    to,
+    subject,
+    html,
+  });
+};

--- a/apps/auth/src/utils/templates/emailVerificationTemplate.ts
+++ b/apps/auth/src/utils/templates/emailVerificationTemplate.ts
@@ -1,0 +1,60 @@
+export const emailTemplate = (verificationLink: string) => `
+  <!DOCTYPE html>
+  <html lang="es">
+    <head>
+      <meta charset="UTF-8" />
+      <title>Verifica tu cuenta | Ayün Pet</title>
+      <style>
+        body {
+          font-family: Arial, sans-serif;
+          background-color: #f8f9fa;
+          color: #333;
+          padding: 20px;
+        }
+        .container {
+          background: #fff;
+          border-radius: 10px;
+          padding: 30px;
+          max-width: 500px;
+          margin: 0 auto;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .logo {
+          text-align: center;
+          margin-bottom: 20px;
+        }
+        .button {
+          display: inline-block;
+          padding: 12px 25px;
+          background-color: #f5b000;
+          color: #000;
+          text-decoration: none;
+          border-radius: 8px;
+          font-weight: bold;
+        }
+        .footer {
+          font-size: 0.85em;
+          color: #666;
+          margin-top: 25px;
+          text-align: center;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <div class="logo">
+          <img src="https://ayunpet.s3.amazonaws.com/logo.png" alt="Ayün Pet Logo" width="80" />
+        </div>
+        <h2>¡Bienvenido a Ayün Pet! 🐾</h2>
+        <p>Gracias por registrarte en nuestra plataforma. Antes de comenzar, necesitamos confirmar tu dirección de correo electrónico.</p>
+        <p style="text-align:center; margin: 30px 0;">
+          <a href="${verificationLink}" class="button">Verificar mi correo</a>
+        </p>
+        <p>Si no creaste una cuenta, puedes ignorar este mensaje.</p>
+        <div class="footer">
+          © ${new Date().getFullYear()} Ayün Pet — Todos los derechos reservados.
+        </div>
+      </div>
+    </body>
+  </html>
+`;


### PR DESCRIPTION
Se añadió plantilla HTML predeterminada y envío automático de correo con token JWT para validar la cuenta de usuario. Probado exitosamente con correo real.