### PR TITLE
feat: documentar endpoints de reports, messages y auth

### DIFF
--- a/apps/gateway/src/docs/endpoints/auth.ts
+++ b/apps/gateway/src/docs/endpoints/auth.ts
@@ -82,9 +82,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // POST /v1/auth/verify-email
-    // ============================================
     registry.registerPath({
         method: "post",
         path: "/v1/auth/verify-email",
@@ -129,9 +126,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // POST /v1/auth/forgot-password
-    // ============================================
     registry.registerPath({
         method: "post",
         path: "/v1/auth/forgot-password",
@@ -175,9 +169,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // POST /v1/auth/reset-password
-    // ============================================
     registry.registerPath({
         method: "post",
         path: "/v1/auth/reset-password",
@@ -226,9 +217,6 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // GET /v1/auth/test-email (solo entorno de prueba)
-    // ============================================
     registry.registerPath({
         method: "get",
         path: "/v1/auth/test-email",

--- a/apps/gateway/src/docs/endpoints/auth.ts
+++ b/apps/gateway/src/docs/endpoints/auth.ts
@@ -8,10 +8,17 @@ import {
 } from "@repo/utils"
 
 export function registerAuthPaths(registry: OpenAPIRegistry) {
+    // ============================================
+    // POST /v1/auth/login
+    // ============================================
     registry.registerPath({
         method: "post",
         path: "/v1/auth/login",
         tags: ["Auth"],
+        summary: "Iniciar sesión en la plataforma",
+        description:
+            "Permite que un usuario inicie sesión proporcionando su correo electrónico y contraseña. " +
+            "Si las credenciales son válidas, devuelve un token JWT y los datos básicos del usuario autenticado.",
         request: {
             body: {
                 content: { "application/json": { schema: LoginSchema } },
@@ -23,7 +30,7 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
                 content: { "application/json": { schema: LoginResponseSchema } },
             },
             404: {
-                description: "Usuario no existe",
+                description: "El usuario no existe",
                 content: { "application/json": { schema: ErrorValuesSchema } },
             },
             401: {
@@ -33,10 +40,27 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
     })
 
+    // ============================================
+    // POST /v1/auth/register/:variation
+    // ============================================
     registry.registerPath({
         method: "post",
-        path: "/v1/auth/register",
+        path: "/v1/auth/register/{variation}",
         tags: ["Auth"],
+        summary: "Registrar un nuevo usuario en la plataforma",
+        description:
+            "Crea un nuevo usuario con base en la variación indicada (`user`, `giver` o `shelter`). " +
+            "Durante el registro, si el usuario es de tipo normal (`user`), se enviará un correo de verificación " +
+            "con un token único para validar su dirección de correo electrónico.",
+        parameters: [
+            {
+                name: "variation",
+                in: "path",
+                required: true,
+                description: "Tipo de usuario a registrar (`user`, `giver`, `shelter`)",
+                schema: { type: "string", example: "user" },
+            },
+        ],
         request: {
             body: {
                 content: { "application/json": { schema: RegisterSchema } },
@@ -44,11 +68,199 @@ export function registerAuthPaths(registry: OpenAPIRegistry) {
         },
         responses: {
             201: {
-                description: "Creación de cuenta exitosa",
+                description: "Usuario creado exitosamente — correo de verificación enviado",
                 content: { "application/json": { schema: BaseResponseSchema } },
             },
             409: {
-                description: "Conflicto de crendeciales",
+                description: "El correo o RUT ya están registrados",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            500: {
+                description: "Error interno al registrar el usuario",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // POST /v1/auth/verify-email
+    // ============================================
+    registry.registerPath({
+        method: "post",
+        path: "/v1/auth/verify-email",
+        tags: ["Auth"],
+        summary: "Verificar correo electrónico del usuario",
+        description:
+            "Endpoint utilizado por el frontend tras hacer clic en el enlace de verificación enviado por correo. " +
+            "Recibe un token generado durante el registro, lo valida y actualiza el campo `validated` del usuario a `true`.",
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                token: {
+                                    type: "string",
+                                    description:
+                                        "Token único recibido desde el correo de verificación",
+                                    example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                },
+                            },
+                            required: ["token"],
+                        },
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "Correo verificado correctamente",
+                content: { "application/json": { schema: BaseResponseSchema } },
+            },
+            400: {
+                description: "Token inválido o expirado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            404: {
+                description: "Usuario no encontrado para este token",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // POST /v1/auth/forgot-password
+    // ============================================
+    registry.registerPath({
+        method: "post",
+        path: "/v1/auth/forgot-password",
+        tags: ["Auth"],
+        summary: "Solicitar recuperación de contraseña",
+        description:
+            "Recibe una dirección de correo electrónico registrada en la plataforma y envía un correo con un enlace " +
+            "que contiene un token único con validez de 30 minutos para restablecer la contraseña.",
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                email: {
+                                    type: "string",
+                                    format: "email",
+                                    example: "usuario@ejemplo.com",
+                                },
+                            },
+                            required: ["email"],
+                        },
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "Correo de recuperación enviado correctamente",
+                content: { "application/json": { schema: BaseResponseSchema } },
+            },
+            404: {
+                description: "Correo no asociado a ningún usuario",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            500: {
+                description: "Error al enviar el correo de recuperación",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // POST /v1/auth/reset-password
+    // ============================================
+    registry.registerPath({
+        method: "post",
+        path: "/v1/auth/reset-password",
+        tags: ["Auth"],
+        summary: "Restablecer contraseña mediante token",
+        description:
+            "Permite al usuario establecer una nueva contraseña utilizando el token recibido en el correo de recuperación. " +
+            "El token es validado y, si es correcto, la contraseña se actualiza en la base de datos con el hash correspondiente.",
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                token: {
+                                    type: "string",
+                                    description: "Token único enviado por correo",
+                                    example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                },
+                                password: {
+                                    type: "string",
+                                    description: "Nueva contraseña segura del usuario",
+                                    example: "Nuev@Contr4seña123!",
+                                },
+                            },
+                            required: ["token", "password"],
+                        },
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "Contraseña restablecida correctamente",
+                content: { "application/json": { schema: BaseResponseSchema } },
+            },
+            400: {
+                description: "Token inválido o expirado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            500: {
+                description: "Error al actualizar la contraseña",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // GET /v1/auth/test-email (solo entorno de prueba)
+    // ============================================
+    registry.registerPath({
+        method: "get",
+        path: "/v1/auth/test-email",
+        tags: ["Auth - Debug"],
+        summary: "Probar envío de correo de verificación (entorno de desarrollo)",
+        description:
+            "Endpoint temporal para pruebas locales de envío de correos. " +
+            "Genera un token de ejemplo y envía un correo de verificación utilizando Nodemailer.",
+        responses: {
+            200: {
+                description: "Correo de prueba enviado correctamente",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            properties: {
+                                ok: { type: "boolean", example: true },
+                                message: {
+                                    type: "string",
+                                    example: "Correo de prueba enviado correctamente",
+                                },
+                                link: {
+                                    type: "string",
+                                    example: "http://localhost:8081/verify-email?token=abc123",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            500: {
+                description: "Error al enviar el correo de prueba",
                 content: { "application/json": { schema: ErrorValuesSchema } },
             },
         },

--- a/apps/gateway/src/docs/endpoints/messages.ts
+++ b/apps/gateway/src/docs/endpoints/messages.ts
@@ -1,0 +1,215 @@
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import { MessageInsertSchema, MessageUpdateSchema, ErrorValuesSchema } from "@repo/utils"
+
+export function registerMessagesDocs(registry: OpenAPIRegistry) {
+    // ============================================
+    // GET /v1/messages
+    // ============================================
+    registry.registerPath({
+        method: "get",
+        path: "/v1/messages",
+        tags: ["Messages"],
+        summary: "Listar todos los mensajes del sistema",
+        description:
+            "Obtiene la lista completa de mensajes registrados en la plataforma. " +
+            "Cada mensaje está asociado a una publicación y muestra los datos del usuario emisor y receptor. " +
+            "Este endpoint requiere autenticación con token JWT.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: "Lista de mensajes obtenida correctamente",
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "array",
+                            items: { $ref: "#/components/schemas/MessageInsertSchema" },
+                        },
+                    },
+                },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            500: {
+                description: "Error al obtener los mensajes",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // GET /v1/messages/{id}
+    // ============================================
+    registry.registerPath({
+        method: "get",
+        path: "/v1/messages/{id}",
+        tags: ["Messages"],
+        summary: "Obtener mensaje por ID",
+        description:
+            "Devuelve los detalles de un mensaje específico identificado por su ID. " +
+            "Incluye el contenido, la fecha de envío y los IDs del emisor y receptor.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID numérico del mensaje a consultar",
+                schema: { type: "integer", example: 8 },
+            },
+        ],
+        responses: {
+            200: {
+                description: "Mensaje obtenido correctamente",
+                content: {
+                    "application/json": {
+                        schema: { $ref: "#/components/schemas/MessageInsertSchema" },
+                    },
+                },
+            },
+            404: {
+                description: "Mensaje no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // POST /v1/messages
+    // ============================================
+    registry.registerPath({
+        method: "post",
+        path: "/v1/messages",
+        tags: ["Messages"],
+        summary: "Enviar un nuevo mensaje",
+        description:
+            "Permite que un usuario autenticado envíe un nuevo mensaje a otro usuario asociado a una publicación de adopción. " +
+            "Este endpoint se utiliza dentro del flujo de comunicación entre adoptantes y refugios.",
+        security: [{ bearerAuth: [] }],
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: MessageInsertSchema,
+                        example: {
+                            creatorId: 4,
+                            postId: 12,
+                            description: "Hola, estoy interesado en adoptar a Luna 🐾",
+                        },
+                    },
+                },
+            },
+        },
+        responses: {
+            201: {
+                description: "Mensaje enviado exitosamente",
+                content: {
+                    "application/json": {
+                        schema: MessageInsertSchema,
+                    },
+                },
+            },
+            400: {
+                description: "Error en los datos del mensaje",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // PUT /v1/messages/{id}
+    // ============================================
+    registry.registerPath({
+        method: "put",
+        path: "/v1/messages/{id}",
+        tags: ["Messages"],
+        summary: "Editar el contenido de un mensaje existente",
+        description:
+            "Permite modificar el texto de un mensaje ya enviado. " +
+            "Solo el autor del mensaje o un administrador pueden realizar esta acción.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID del mensaje que se desea actualizar",
+                schema: { type: "integer", example: 10 },
+            },
+        ],
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: MessageUpdateSchema,
+                        example: {
+                            description: "Corrijo el mensaje anterior — aún estoy interesado 😅",
+                        },
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "Mensaje actualizado correctamente",
+                content: {
+                    "application/json": {
+                        schema: MessageUpdateSchema,
+                    },
+                },
+            },
+            404: {
+                description: "Mensaje no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // DELETE /v1/messages/{id}
+    // ============================================
+    registry.registerPath({
+        method: "delete",
+        path: "/v1/messages/{id}",
+        tags: ["Messages"],
+        summary: "Eliminar un mensaje del sistema",
+        description:
+            "Elimina permanentemente un mensaje existente. " +
+            "Solo el emisor original o un administrador tienen permisos para eliminar mensajes. " +
+            "La eliminación no se puede deshacer.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID numérico del mensaje que se desea eliminar",
+                schema: { type: "integer", example: 10 },
+            },
+        ],
+        responses: {
+            200: { description: "Mensaje eliminado correctamente" },
+            404: {
+                description: "Mensaje no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+}

--- a/apps/gateway/src/docs/endpoints/messages.ts
+++ b/apps/gateway/src/docs/endpoints/messages.ts
@@ -2,9 +2,7 @@ import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
 import { MessageInsertSchema, MessageUpdateSchema, ErrorValuesSchema } from "@repo/utils"
 
 export function registerMessagesDocs(registry: OpenAPIRegistry) {
-    // ============================================
-    // GET /v1/messages
-    // ============================================
+
     registry.registerPath({
         method: "get",
         path: "/v1/messages",
@@ -38,9 +36,6 @@ export function registerMessagesDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // GET /v1/messages/{id}
-    // ============================================
     registry.registerPath({
         method: "get",
         path: "/v1/messages/{id}",
@@ -79,9 +74,6 @@ export function registerMessagesDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // POST /v1/messages
-    // ============================================
     registry.registerPath({
         method: "post",
         path: "/v1/messages",
@@ -125,9 +117,6 @@ export function registerMessagesDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // PUT /v1/messages/{id}
-    // ============================================
     registry.registerPath({
         method: "put",
         path: "/v1/messages/{id}",
@@ -178,9 +167,7 @@ export function registerMessagesDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // DELETE /v1/messages/{id}
-    // ============================================
+
     registry.registerPath({
         method: "delete",
         path: "/v1/messages/{id}",

--- a/apps/gateway/src/docs/endpoints/reports.ts
+++ b/apps/gateway/src/docs/endpoints/reports.ts
@@ -7,9 +7,7 @@ import {
 } from "@repo/utils"
 
 export function registerReportsDocs(registry: OpenAPIRegistry) {
-    // ============================================
-    // GET /v1/reports
-    // ============================================
+
     registry.registerPath({
         method: "get",
         path: "/v1/reports",
@@ -39,9 +37,6 @@ export function registerReportsDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // GET /v1/reports/{id}
-    // ============================================
     registry.registerPath({
         method: "get",
         path: "/v1/reports/{id}",
@@ -79,9 +74,7 @@ export function registerReportsDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // POST /v1/reports
-    // ============================================
+
     registry.registerPath({
         method: "post",
         path: "/v1/reports",
@@ -120,9 +113,6 @@ export function registerReportsDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // PUT /v1/reports/{id}
-    // ============================================
     registry.registerPath({
         method: "put",
         path: "/v1/reports/{id}",
@@ -165,9 +155,6 @@ export function registerReportsDocs(registry: OpenAPIRegistry) {
         },
     })
 
-    // ============================================
-    // DELETE /v1/reports/{id}
-    // ============================================
     registry.registerPath({
         method: "delete",
         path: "/v1/reports/{id}",

--- a/apps/gateway/src/docs/endpoints/reports.ts
+++ b/apps/gateway/src/docs/endpoints/reports.ts
@@ -1,0 +1,200 @@
+import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
+import {
+    ReportInsertSchema,
+    ReportUpdateSchema,
+    ReportResponseSchema,
+    ErrorValuesSchema,
+} from "@repo/utils"
+
+export function registerReportsDocs(registry: OpenAPIRegistry) {
+    // ============================================
+    // GET /v1/reports
+    // ============================================
+    registry.registerPath({
+        method: "get",
+        path: "/v1/reports",
+        tags: ["Reports"],
+        summary: "Listar todos los reportes registrados",
+        description:
+            "Obtiene la lista completa de reportes creados por los usuarios. " +
+            "Incluye información sobre el usuario denunciante, la publicación reportada y la descripción del reporte.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+            200: {
+                description: "Lista de reportes obtenida correctamente",
+                content: {
+                    "application/json": {
+                        schema: ReportResponseSchema,
+                    },
+                },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            500: {
+                description: "Error interno del servidor",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // GET /v1/reports/{id}
+    // ============================================
+    registry.registerPath({
+        method: "get",
+        path: "/v1/reports/{id}",
+        tags: ["Reports"],
+        summary: "Obtener un reporte específico por ID",
+        description:
+            "Devuelve la información completa de un reporte determinado, incluyendo los datos del usuario y la publicación asociada.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID numérico del reporte a consultar",
+                schema: { type: "integer", example: 15 },
+            },
+        ],
+        responses: {
+            200: {
+                description: "Reporte obtenido correctamente",
+                content: {
+                    "application/json": {
+                        schema: ReportResponseSchema,
+                    },
+                },
+            },
+            404: {
+                description: "Reporte no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // POST /v1/reports
+    // ============================================
+    registry.registerPath({
+        method: "post",
+        path: "/v1/reports",
+        tags: ["Reports"],
+        summary: "Crear un nuevo reporte",
+        description:
+            "Permite a los usuarios crear un nuevo reporte sobre una publicación inapropiada o sospechosa. " +
+            "El usuario debe estar autenticado para poder generar un reporte.",
+        security: [{ bearerAuth: [] }],
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: ReportInsertSchema,
+                    },
+                },
+            },
+        },
+        responses: {
+            201: {
+                description: "Reporte creado exitosamente",
+                content: {
+                    "application/json": {
+                        schema: ReportResponseSchema,
+                    },
+                },
+            },
+            400: {
+                description: "Error en los datos del reporte",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // PUT /v1/reports/{id}
+    // ============================================
+    registry.registerPath({
+        method: "put",
+        path: "/v1/reports/{id}",
+        tags: ["Reports"],
+        summary: "Actualizar la descripción de un reporte existente",
+        description:
+            "Permite modificar la descripción de un reporte. Solo usuarios autorizados pueden realizar esta acción.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID del reporte a actualizar",
+                schema: { type: "integer", example: 15 },
+            },
+        ],
+        request: {
+            body: {
+                content: {
+                    "application/json": {
+                        schema: ReportUpdateSchema,
+                    },
+                },
+            },
+        },
+        responses: {
+            200: {
+                description: "Reporte actualizado correctamente",
+                content: {
+                    "application/json": {
+                        schema: ReportResponseSchema,
+                    },
+                },
+            },
+            404: {
+                description: "Reporte no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+
+    // ============================================
+    // DELETE /v1/reports/{id}
+    // ============================================
+    registry.registerPath({
+        method: "delete",
+        path: "/v1/reports/{id}",
+        tags: ["Reports"],
+        summary: "Eliminar un reporte existente",
+        description:
+            "Elimina un reporte determinado por su ID. Solo administradores tienen permisos para eliminar reportes.",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+            {
+                name: "id",
+                in: "path",
+                required: true,
+                description: "ID del reporte a eliminar",
+                schema: { type: "integer", example: 15 },
+            },
+        ],
+        responses: {
+            200: { description: "Reporte eliminado correctamente" },
+            404: {
+                description: "Reporte no encontrado",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+            401: {
+                description: "No autenticado - Token JWT requerido",
+                content: { "application/json": { schema: ErrorValuesSchema } },
+            },
+        },
+    })
+}

--- a/apps/gateway/src/docs/openapi.ts
+++ b/apps/gateway/src/docs/openapi.ts
@@ -1,8 +1,8 @@
 import { OpenAPIRegistry, OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi"
 import { registerAuthPaths } from "./endpoints/auth"
-import { 
-    mineRequestDocs, 
-    ConfirmAcceptDocs, 
+import {
+    mineRequestDocs,
+    ConfirmAcceptDocs,
     validateCodeDocs,
     listPublicationsDocs,
     getPublicationByIdDocs,
@@ -22,6 +22,9 @@ import {
     getAdoptionRequestByIdDocs,
 } from "./endpoints/entities"
 
+import { registerReportsDocs } from "./endpoints/reports"
+import { registerMessagesDocs } from "./endpoints/messages"
+
 export function buildOpenApi() {
     const registry = new OpenAPIRegistry()
 
@@ -38,7 +41,7 @@ export function buildOpenApi() {
     mineRequestDocs(registry)
     ConfirmAcceptDocs(registry)
     validateCodeDocs(registry)
-    
+
     // Adoptions endpoints con imágenes (comunicación entre microservicios)
     listPublicationsDocs(registry)
     getPublicationByIdDocs(registry)
@@ -52,12 +55,18 @@ export function buildOpenApi() {
     createAdoptionHistoryDocs(registry)
     updateAdoptionHistoryDocs(registry)
     deleteAdoptionHistoryDocs(registry)
-    
+
     // Entities endpoints con imágenes (comunicación entre microservicios)
     getUsersDocs(registry)
     getUserByIdDocs(registry)
     getAdoptionRequestsDocs(registry)
     getAdoptionRequestByIdDocs(registry)
+
+    // Reports endpoints
+    registerReportsDocs(registry)
+
+    // Messages endpoints
+    registerMessagesDocs(registry)
 
     const generator = new OpenApiGeneratorV3(registry.definitions)
 

--- a/packages/utils/src/schemas/auth.ts
+++ b/packages/utils/src/schemas/auth.ts
@@ -1,0 +1,29 @@
+import { z } from "zod"
+
+export const VerifyEmailRequestSchema = z.object({
+  token: z.string().min(10, "El token es requerido."),
+})
+export const VerifyEmailResponseSchema = z.object({
+  message: z.string(),
+  type: z.enum(["success", "error"]),
+  data: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const ForgotPasswordRequestSchema = z.object({
+  email: z.string().email("Debe ser un correo válido."),
+})
+export const ForgotPasswordResponseSchema = z.object({
+  message: z.string(),
+  type: z.enum(["success", "error"]),
+  data: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const ResetPasswordRequestSchema = z.object({
+  token: z.string().min(10),
+  newPassword: z.string().min(6, "La contraseña debe tener mínimo 6 caracteres."),
+})
+export const ResetPasswordResponseSchema = z.object({
+  message: z.string(),
+  type: z.enum(["success", "error"]),
+  data: z.record(z.string(), z.unknown()).optional(),
+})

--- a/packages/utils/src/schemas/index.ts
+++ b/packages/utils/src/schemas/index.ts
@@ -4,6 +4,9 @@ import { validarRUT } from "../rut"
 export * from "./entities"
 export * from "./responses"
 export * from "./adoption"
+export * from "./report"
+export * from "./message"
+export * from "./auth"
 
 export const roleSchema = z.object({
     id: z.number("Se debe ingresar un id valido"),

--- a/packages/utils/src/schemas/message.ts
+++ b/packages/utils/src/schemas/message.ts
@@ -1,0 +1,19 @@
+import { z } from "zod"
+
+export const MessageBaseSchema = z.object({
+  id: z.number().optional(),
+  senderId: z.number(),
+  receiverId: z.number(),
+  content: z.string().min(1, "El mensaje no puede estar vacío."),
+  created_at: z.string().optional(),
+})
+
+export const MessageInsertSchema = MessageBaseSchema.omit({ id: true, created_at: true })
+
+export const MessageUpdateSchema = MessageInsertSchema.partial()
+
+export const MessageResponseSchema = MessageBaseSchema
+
+export type MessageInsert = z.infer<typeof MessageInsertSchema>
+export type MessageUpdate = z.infer<typeof MessageUpdateSchema>
+export type MessageResponse = z.infer<typeof MessageResponseSchema>

--- a/packages/utils/src/schemas/report.ts
+++ b/packages/utils/src/schemas/report.ts
@@ -1,0 +1,20 @@
+import { z } from "zod"
+
+export const ReportBaseSchema = z.object({
+  id: z.number().optional(),
+  userId: z.number(),
+  postId: z.number(),
+  description: z.string().min(5, "La descripción debe tener al menos 5 caracteres."),
+  created_at: z.string().optional(),
+})
+
+
+export const ReportInsertSchema = ReportBaseSchema.omit({ id: true, created_at: true })
+
+export const ReportUpdateSchema = ReportInsertSchema.partial()
+
+export const ReportResponseSchema = ReportBaseSchema
+
+export type ReportInsert = z.infer<typeof ReportInsertSchema>
+export type ReportUpdate = z.infer<typeof ReportUpdateSchema>
+export type ReportResponse = z.infer<typeof ReportResponseSchema>


### PR DESCRIPTION
Se implementa documentación completa de endpoints desarrollados:  - Reports: CRUD documentado con schemas reutilizados desde @repo/utils. - Messages: CRUD con ejemplos, descripción y autenticación JWT. - Auth: endpoints de login, registro, verificación de correo, recuperación y restablecimiento de contraseña.