### PR TITLE
feat: implementación de vista de confirmación de adopción según rol

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,6 +17,7 @@
             }
         },
         "android": {
+            "softwareKeyboardLayoutMode": "pan",
             "adaptiveIcon": {
                 "foregroundImage": "./assets/images/adaptive-icon.png",
                 "backgroundColor": "#ffffff"

--- a/apps/mobile/app/(shelter)/requests/[id].tsx
+++ b/apps/mobile/app/(shelter)/requests/[id].tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { View, ScrollView, StyleSheet } from "react-native"
+import { useLocalSearchParams, useRouter } from "expo-router"
+import RequestDetailCard, { Status } from "@/components/common/RequestDetailCard"
+
+export default function ShelterRequestDetail() {
+    const router = useRouter()
+    const { id } = useLocalSearchParams()
+
+    const solicitud = {
+        id: Number(id),
+        petPhoto: "https://placekitten.com/400/400",
+        petName: "Luna",
+        requester: "Juan Pérez",
+        date: "2025-10-18",
+        status: "Aceptada" as Status,
+        message: "Me encantaría adoptar a Luna y darle un hogar lleno de amor.",
+    }
+
+    const handleAccept = () => {
+        console.log("Solicitud aceptada")
+        router.back()
+    }
+
+    const handleReject = () => {
+        console.log("Solicitud rechazada")
+        router.back()
+    }
+
+    const handleConfirmCode = (codigo: string) => {
+        console.log("Código confirmado:", codigo)
+        router.back()
+    }
+
+    return (
+        <ScrollView contentContainerStyle={styles.container}>
+            <RequestDetailCard
+                petPhoto={solicitud.petPhoto}
+                petName={solicitud.petName}
+                requester={solicitud.requester}
+                date={solicitud.date}
+                status={solicitud.status}
+                message={solicitud.message}
+                onAccept={handleAccept}
+                onReject={handleReject}
+            />
+        </ScrollView>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        padding: 16,
+    },
+})

--- a/apps/mobile/app/(shelter)/requests/requestList.tsx
+++ b/apps/mobile/app/(shelter)/requests/requestList.tsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from "react"
+import { SafeAreaView, View, Text, FlatList, StyleSheet, Alert } from "react-native"
+import { useRouter } from "expo-router"
+import RequestCard, { RequestStatus } from "@/components/common/RequestCard"
+import { useAuthContext } from "@/context/AuthContext"
+import { Status } from "@/components/common/RequestDetailCard"
+
+const MOCK = [
+    {
+        id: "1",
+        petName: "Firulais",
+        adoptante: "Pepito Pérez",
+        estado: "Pendiente" as Status,
+        petPhoto:
+            "https://images.unsplash.com/photo-1543466835-00a7907e9de1?q=80&w=800&auto=format&fit=crop",
+        fecha: "11 de Abril de 2025",
+    },
+    {
+        id: "2",
+        petName: "Luna",
+        adoptante: "María López",
+        estado: "Aceptada" as Status,
+        petPhoto:
+            "https://images.unsplash.com/photo-1543466835-00a7907e9de1?q=80&w=800&auto=format&fit=crop",
+        fecha: "12 de Abril de 2025",
+    },
+    {
+        id: "3",
+        petName: "Toby",
+        adoptante: "Andrés Valdés",
+        estado: "Rechazada" as Status,
+        petPhoto:
+            "https://images.unsplash.com/photo-1574158622682-e40e69881006?q=80&w=800&auto=format&fit=crop",
+        fecha: "13 de Abril de 2025",
+    },
+]
+
+export default function ShelterRequests() {
+    const router = useRouter()
+    const { user } = useAuthContext()
+    const role = user?.role
+
+    const solicitudes = useMemo(() => MOCK, [])
+
+    const handleAccept = (id: string) => {
+        Alert.alert("✔", `Solicitud ${id} aceptada`)
+    }
+
+    const handleReject = (id: string) => {
+        Alert.alert("✘", `Solicitud ${id} rechazada`)
+    }
+
+    return (
+        <SafeAreaView style={styles.container}>
+            <FlatList
+                contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
+                ListHeaderComponent={
+                    <View style={{ gap: 6, marginBottom: 8 }}>
+                        <Text style={styles.h1}>Solicitudes de adopción</Text>
+                        <Text style={styles.sub}>Gestiona las solicitudes de tus mascotas</Text>
+                    </View>
+                }
+                data={solicitudes}
+                keyExtractor={(i) => i.id}
+                ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+                renderItem={({ item }) => (
+                    <RequestCard
+                        petPhoto={item.petPhoto}
+                        petName={item.petName}
+                        requester={item.adoptante}
+                        date={item.fecha}
+                        status={item.estado}
+                        onPress={() =>
+                            router.push({
+                                pathname: "/(shelter)/requests/[id]",
+                                params: { id: item.id },
+                            })
+                        }
+                    />
+                )}
+            />
+        </SafeAreaView>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, backgroundColor: "#F2F2F2" },
+    h1: { fontSize: 22, fontWeight: "900", color: "#1C1C1C" },
+    sub: { color: "#6B6B6B" },
+})

--- a/apps/mobile/components/common/BottomNavbar.tsx
+++ b/apps/mobile/components/common/BottomNavbar.tsx
@@ -22,7 +22,9 @@ export default function BottomNavbar() {
                     !pathname.includes("/AddPetScreen"))
             )
         }
-        if (tabPath === "requests") return pathname.includes("/(requests)")
+        if (tabPath === "requests")
+            return pathname.includes("/(requests)") || pathname.includes("/requests")
+
         if (tabPath === "publications") return pathname.includes("/my-publications")
         if (tabPath === "profile") return pathname.includes("/my-profile")
         if (tabPath === "dashboard") return pathname.includes("/(dashboard)")
@@ -37,7 +39,6 @@ export default function BottomNavbar() {
 
     const renderTabsByRole = () => {
         switch (role) {
-            // Usuario adoptante
             case 20:
                 return (
                     <>
@@ -57,7 +58,7 @@ export default function BottomNavbar() {
                             onPress={() => router.push("/(home)/(requests)/requestList")}
                         >
                             <Ionicons
-                                name={getIconName("search", "requests")}
+                                name={getIconName("mail", "requests")}
                                 size={26}
                                 color={getIconColor("requests")}
                             />
@@ -94,7 +95,6 @@ export default function BottomNavbar() {
                     </>
                 )
 
-            // rol de Organización/Shelter y Giver
             case 21:
             case 22:
                 return (
@@ -111,13 +111,13 @@ export default function BottomNavbar() {
                         </Pressable>
 
                         <Pressable
-                            style={getTabStyle("publications")}
+                            style={getTabStyle("dashboard")}
                             onPress={() => router.push("/(shelter)/dashboard")}
                         >
                             <Ionicons
-                                name={getIconName("stats-chart", "publications")}
+                                name={getIconName("stats-chart", "dashboard")}
                                 size={26}
-                                color={getIconColor("publications")}
+                                color={getIconColor("dashboard")}
                             />
                         </Pressable>
 
@@ -130,7 +130,8 @@ export default function BottomNavbar() {
 
                         <Pressable
                             style={getTabStyle("requests")}
-                            onPress={() => router.push("/(shelter)/dashboard")}
+                            // 👇 ruta correcta según tu estructura: app/(shelter)/requests/requestList.tsx
+                            onPress={() => router.push("/(shelter)/requests/requestList")}
                         >
                             <Ionicons
                                 name={getIconName("mail", "requests")}
@@ -141,7 +142,7 @@ export default function BottomNavbar() {
 
                         <Pressable
                             style={getTabStyle("profile")}
-                            onPress={() => router.push("/(shelter)/dashboard")}
+                            onPress={() => router.push("/(shelter)/my-profile")}
                         >
                             <Ionicons
                                 name={getIconName("person", "profile")}
@@ -152,7 +153,6 @@ export default function BottomNavbar() {
                     </>
                 )
 
-            // rol de Administrador
             case 19:
                 return (
                     <>

--- a/apps/mobile/components/common/RequestCard.tsx
+++ b/apps/mobile/components/common/RequestCard.tsx
@@ -67,11 +67,7 @@ const styles = StyleSheet.create({
         shadowRadius: 6,
         shadowOffset: { width: 0, height: 3 },
     },
-    photo: {
-        width: 86,
-        height: 86,
-        borderRadius: 12,
-    },
+    photo: { width: 86, height: 86, borderRadius: 12 },
     body: { flex: 1 },
     headerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
     petName: { fontSize: 16, fontWeight: "700", color: "#1C1C1C" },

--- a/apps/mobile/components/common/RequestDetailCard.tsx
+++ b/apps/mobile/components/common/RequestDetailCard.tsx
@@ -1,5 +1,16 @@
-import React from "react"
-import { View, Text, Image, StyleSheet, Pressable, ScrollView } from "react-native"
+import React, { useState } from "react"
+import {
+    View,
+    Text,
+    Image,
+    Pressable,
+    KeyboardAvoidingView,
+    Platform,
+    ScrollView,
+    TextInput,
+    StyleSheet,
+} from "react-native"
+import { useAuthContext } from "@/context/AuthContext"
 
 export type Status = "Pendiente" | "Aceptada" | "Rechazada"
 
@@ -12,12 +23,7 @@ export interface RequestDetailProps {
     message?: string
     onAccept?: () => void
     onReject?: () => void
-}
-
-const statusStyles: Record<Status, { bg: string; fg: string }> = {
-    Pendiente: { bg: "#FFE8A3", fg: "#6A4B00" },
-    Aceptada: { bg: "#D1F3DA", fg: "#0E6B2B" },
-    Rechazada: { bg: "#FAD2D2", fg: "#8B1A1A" },
+    onConfirmCode?: (code: string) => void
 }
 
 export default function RequestDetailCard({
@@ -29,68 +35,130 @@ export default function RequestDetailCard({
     message,
     onAccept,
     onReject,
+    onConfirmCode,
 }: RequestDetailProps) {
+    const { user } = useAuthContext()
+    const role = user?.role
+    const [code, setCode] = useState("")
+
+    const statusStyles: Record<Status, { bg: string; fg: string }> = {
+        Pendiente: { bg: "#FFE8A3", fg: "#6A4B00" },
+        Aceptada: { bg: "#D1F3DA", fg: "#0E6B2B" },
+        Rechazada: { bg: "#FAD2D2", fg: "#8B1A1A" },
+    }
+
     const st = statusStyles[status]
 
     return (
-        <ScrollView
-            contentContainerStyle={{ paddingBottom: 40 }}
-            showsVerticalScrollIndicator={false}
+        <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={Platform.OS === "ios" ? 100 : 0}
         >
-            <Image source={{ uri: petPhoto }} style={styles.photo} />
+            <ScrollView
+                contentContainerStyle={{ paddingBottom: 80 }}
+                showsVerticalScrollIndicator={false}
+                keyboardShouldPersistTaps="handled"
+            >
+                <Image source={{ uri: petPhoto }} style={styles.photo} />
 
-            <View style={styles.card}>
-                <View style={styles.titleRow}>
-                    <Text style={styles.petName}>{petName}</Text>
-                    <View style={[styles.badge, { backgroundColor: st.bg }]}>
-                        <Text style={[styles.badgeText, { color: st.fg }]}>{status}</Text>
+                <View style={styles.card}>
+                    <View style={styles.titleRow}>
+                        <Text style={styles.petName}>{petName}</Text>
+                        <View style={[styles.badge, { backgroundColor: st.bg }]}>
+                            <Text style={[styles.badgeText, { color: st.fg }]}>{status}</Text>
+                        </View>
                     </View>
-                </View>
 
-                <Text style={styles.sectionTitle}>Detalles de solicitud:</Text>
-
-                <View style={styles.row}>
-                    <Text style={styles.label}>Solicitante: </Text>
-                    <Text style={styles.value}>{requester}</Text>
-                </View>
-
-                <View style={styles.row}>
-                    <Text style={styles.label}>Fecha: </Text>
-                    <Text style={styles.value}>{date}</Text>
-                </View>
-
-                {message && (
-                    <View style={[styles.row, { alignItems: "flex-start" }]}>
-                        <Text style={styles.label}>Mensaje: </Text>
-                        <Text style={[styles.value, { flex: 1 }]}>{message}</Text>
+                    <Text style={styles.sectionTitle}>Detalles de solicitud:</Text>
+                    <View style={styles.row}>
+                        <Text style={styles.label}>Solicitante: </Text>
+                        <Text style={styles.value}>{requester}</Text>
                     </View>
-                )}
+                    <View style={styles.row}>
+                        <Text style={styles.label}>Fecha: </Text>
+                        <Text style={styles.value}>{date}</Text>
+                    </View>
 
-                {onAccept && (
-                    <Pressable style={[styles.btn, styles.btnAccept]} onPress={onAccept}>
-                        <Text style={styles.btnText}>Aceptar Solicitud</Text>
-                    </Pressable>
-                )}
+                    {message && (
+                        <View style={[styles.row, { alignItems: "flex-start" }]}>
+                            <Text style={styles.label}>Mensaje: </Text>
+                            <Text style={[styles.value, { flex: 1 }]}>{message}</Text>
+                        </View>
+                    )}
 
-                {onReject && (
-                    <Pressable style={[styles.btn, styles.btnReject]} onPress={onReject}>
-                        <Text style={styles.btnText}>Rechazar Solicitud</Text>
-                    </Pressable>
-                )}
-            </View>
-        </ScrollView>
+                    {/* Mostrar código de adopción si es usuario adoptante */}
+                    {role === 20 && status === "Aceptada" && (
+                        <View style={{ marginTop: 10, alignItems: "center" }}>
+                            <Text style={{ fontWeight: "700", color: "#333" }}>
+                                Tu código de adopción es:
+                            </Text>
+                            <Text
+                                style={{
+                                    fontSize: 24,
+                                    fontWeight: "900",
+                                    color: "#2563EB",
+                                    marginTop: 6,
+                                }}
+                            >
+                                {code || "9F27C"}
+                            </Text>
+                            <Text style={{ color: "#666", marginTop: 4, textAlign: "center" }}>
+                                Entrégaselo al dador o refugio para completar la adopción.
+                            </Text>
+                        </View>
+                    )}
+
+                    {/* Botones para refugios/givers */}
+                    {(role === 21 || role === 22) && (
+                        <>
+                            {status === "Pendiente" && (
+                                <View>
+                                    {onAccept && (
+                                        <Pressable
+                                            style={[styles.btn, styles.btnAccept]}
+                                            onPress={onAccept}
+                                        >
+                                            <Text style={styles.btnText}>Aceptar Solicitud</Text>
+                                        </Pressable>
+                                    )}
+                                    {onReject && (
+                                        <Pressable
+                                            style={[styles.btn, styles.btnReject]}
+                                            onPress={onReject}
+                                        >
+                                            <Text style={styles.btnText}>Rechazar Solicitud</Text>
+                                        </Pressable>
+                                    )}
+                                </View>
+                            )}
+
+                            {status === "Aceptada" && (
+                                <View style={{ marginTop: 10 }}>
+                                    <TextInput
+                                        style={styles.input}
+                                        placeholder="Ingrese código de adopción"
+                                        value={code}
+                                        onChangeText={setCode}
+                                    />
+                                    <Pressable
+                                        style={[styles.btn, styles.btnAccept]}
+                                        onPress={() => onConfirmCode?.(code)}
+                                    >
+                                        <Text style={styles.btnText}>Confirmar Código</Text>
+                                    </Pressable>
+                                </View>
+                            )}
+                        </>
+                    )}
+                </View>
+            </ScrollView>
+        </KeyboardAvoidingView>
     )
 }
 
 const styles = StyleSheet.create({
-    photo: {
-        width: "90%",
-        height: 220,
-        borderRadius: 2,
-        marginVertical: 12,
-        alignSelf: "center",
-        justifyContent: "center",
-    },
+    photo: { width: "90%", height: 220, borderRadius: 2, marginVertical: 12, alignSelf: "center" },
     card: {
         backgroundColor: "#fff",
         width: "95%",
@@ -99,17 +167,8 @@ const styles = StyleSheet.create({
         padding: 14,
         gap: 10,
         elevation: 2,
-        shadowColor: "#000",
-        shadowOpacity: 0.08,
-        shadowRadius: 6,
-        shadowOffset: { width: 0, height: 3 },
     },
-    titleRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-        gap: 10,
-    },
+    titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
     petName: { fontSize: 22, fontWeight: "900", color: "#1C1C1C" },
     badge: { paddingHorizontal: 10, paddingVertical: 5, borderRadius: 999 },
     badgeText: { fontSize: 12, fontWeight: "800" },
@@ -117,13 +176,16 @@ const styles = StyleSheet.create({
     row: { flexDirection: "row", alignItems: "center" },
     label: { fontWeight: "800", color: "#1C1C1C" },
     value: { color: "#444" },
-    btn: {
-        marginTop: 10,
-        borderRadius: 10,
-        paddingVertical: 12,
-        alignItems: "center",
-    },
+    btn: { marginTop: 10, borderRadius: 10, paddingVertical: 12, alignItems: "center" },
     btnAccept: { backgroundColor: "#2E8B57" },
     btnReject: { backgroundColor: "#C0392B" },
     btnText: { fontWeight: "800", color: "#fff" },
+    input: {
+        borderWidth: 1,
+        borderColor: "#CCC",
+        borderRadius: 8,
+        marginTop: 6,
+        padding: 8,
+        color: "#333",
+    },
 })

--- a/apps/mobile/components/common/modals/AdoptionAcceptedModal.tsx
+++ b/apps/mobile/components/common/modals/AdoptionAcceptedModal.tsx
@@ -1,74 +1,112 @@
 import React, { useState, useEffect } from "react"
-import { Modal, View, Text, Button, StyleSheet, Animated, Image } from "react-native"
-import { AdoptionRequestProps } from "../../../context/ModalContext"
+import {
+    Modal,
+    View,
+    Text,
+    Button,
+    StyleSheet,
+    Animated,
+    Image,
+    TextInput,
+    Pressable,
+} from "react-native"
+import { useAuthContext } from "@/context/AuthContext"
 
 type AdoptionAcceptedModalProps = {
-    petDetails: Pick<AdoptionRequestProps, "petName">
+    petName: string
+    visible: boolean
+    onClose: () => void
+    onConfirmCode?: (code: string) => void
+    adoptionCode?: string
 }
 
-const AdoptionAcceptedModal = ({ petDetails }: AdoptionAcceptedModalProps) => {
-    const [visible, setVisible] = useState(false)
+const AdoptionAcceptedModal = ({
+    petName,
+    visible,
+    onClose,
+    onConfirmCode,
+    adoptionCode = "9F27C",
+}: AdoptionAcceptedModalProps) => {
     const fadeAnim = new Animated.Value(0)
-
-    const close = () => setVisible(false)
+    const [code, setCode] = useState("")
+    const { user } = useAuthContext()
+    const role = user?.role
+    const showVerification = role === 20
+    const showInput = role === 21 || role === 22
 
     useEffect(() => {
-        if (visible) {
-            Animated.timing(fadeAnim, {
-                toValue: 1,
-                duration: 500,
-                useNativeDriver: true,
-            }).start()
-        } else {
-            Animated.timing(fadeAnim, {
-                toValue: 0,
-                duration: 500,
-                useNativeDriver: true,
-            }).start()
-        }
+        Animated.timing(fadeAnim, {
+            toValue: visible ? 1 : 0,
+            duration: 500,
+            useNativeDriver: true,
+        }).start()
     }, [visible])
 
     return (
-        <>
-            <Modal visible={visible} transparent animationType="fade" onRequestClose={close}>
-                <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
-                    <View style={styles.modalContainer}>
-                        <Image
-                            source={require("../../../assets/images/perro-gato.png")}
-                            style={styles.image}
-                        />
-                        <Text style={styles.title}>¡Solicitud Aceptada!</Text>
-                        <Text style={styles.message}>
-                            Tu solicitud para adoptar a{" "}
-                            <Text style={styles.boldText}>{petDetails.petName}</Text> ha sido
-                            aceptada.
-                        </Text>
-                        <View style={styles.buttonsContainer}>
-                            <Button
-                                title="Ver detalles"
-                                onPress={() => {
-                                    /* Acción */
+        <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+            <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
+                <View style={styles.modalContainer}>
+                    <Image
+                        source={require("../../../assets/images/perro-gato.png")}
+                        style={styles.image}
+                    />
+                    <Text style={styles.title}>¡Solicitud Aceptada!</Text>
+                    <Text style={styles.message}>
+                        Tu solicitud para adoptar a <Text style={styles.boldText}>{petName}</Text>{" "}
+                        ha sido aceptada.
+                    </Text>
+
+                    {showVerification && (
+                        <View style={{ marginTop: 10, alignItems: "center" }}>
+                            <Text style={{ fontWeight: "700", color: "#333" }}>
+                                Tu código de adopción es:
+                            </Text>
+                            <Text
+                                style={{
+                                    fontSize: 24,
+                                    fontWeight: "900",
+                                    color: "#2563EB",
+                                    marginTop: 6,
                                 }}
-                                color="#4CAF50"
-                            />
-                            <Button title="Cerrar" onPress={close} color="#FF5733" />
+                            >
+                                {adoptionCode}
+                            </Text>
+                            <Text style={{ color: "#666", marginTop: 4, textAlign: "center" }}>
+                                Entrégaselo al dador o refugio para completar la adopción.
+                            </Text>
                         </View>
+                    )}
+
+                    {showInput && (
+                        <View style={{ marginTop: 10, width: "100%" }}>
+                            <Text style={{ fontWeight: "700", color: "#333", marginBottom: 6 }}>
+                                Ingresa el código del adoptante:
+                            </Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="Ej: 9F27C"
+                                value={code}
+                                onChangeText={setCode}
+                            />
+                            <Pressable
+                                style={[styles.button, styles.confirmButton]}
+                                onPress={() => onConfirmCode?.(code)}
+                            >
+                                <Text style={styles.buttonText}>Confirmar Código</Text>
+                            </Pressable>
+                        </View>
+                    )}
+
+                    <View style={{ marginTop: 15 }}>
+                        <Button title="Cerrar" onPress={onClose} color="#FF5733" />
                     </View>
-                </Animated.View>
-            </Modal>
-        </>
+                </View>
+            </Animated.View>
+        </Modal>
     )
 }
 
 const styles = StyleSheet.create({
-    testButton: {
-        backgroundColor: "#2563EB",
-        paddingVertical: 10,
-        paddingHorizontal: 20,
-        borderRadius: 8,
-        marginBottom: 20,
-        alignSelf: "center",
-    },
     modalBackground: {
         flex: 1,
         justifyContent: "center",
@@ -80,22 +118,31 @@ const styles = StyleSheet.create({
         padding: 20,
         borderRadius: 20,
         width: 320,
-        height: 400,
+        height: 450,
         justifyContent: "center",
         alignItems: "center",
         elevation: 10,
     },
-    image: {
-        width: 160,
-        height: 160,
-        borderRadius: 80,
-        marginBottom: 20,
-        resizeMode: "cover",
-    },
+    image: { width: 160, height: 160, borderRadius: 80, marginBottom: 20, resizeMode: "cover" },
     title: { fontSize: 22, fontWeight: "bold", marginBottom: 10, color: "#4CAF50" },
     message: { fontSize: 16, marginBottom: 20, color: "#333", textAlign: "center" },
     boldText: { fontWeight: "bold" },
-    buttonsContainer: { width: "100%", gap: 10 },
+    input: {
+        borderWidth: 1,
+        borderColor: "#ccc",
+        borderRadius: 8,
+        padding: 8,
+        marginBottom: 8,
+        color: "#333",
+        width: "100%",
+    },
+    button: {
+        paddingVertical: 12,
+        borderRadius: 10,
+        alignItems: "center",
+    },
+    confirmButton: { backgroundColor: "#1976D2" },
+    buttonText: { color: "#fff", fontWeight: "bold" },
 })
 
 export default AdoptionAcceptedModal

--- a/apps/mobile/components/common/modals/AdoptionRejectedModal.tsx
+++ b/apps/mobile/components/common/modals/AdoptionRejectedModal.tsx
@@ -1,19 +1,23 @@
 import React, { useState, useEffect } from "react"
 import { Modal, View, Text, Button, StyleSheet, Animated, Image } from "react-native"
+import { useAuthContext } from "@/context/AuthContext"
 
 type AdoptionRejectedModalProps = {
-    petDetails: { petName: string }
+    petName: string
+    visible: boolean
+    onClose: () => void
     reason?: string
 }
 
 const AdoptionRejectedModal = ({
-    petDetails,
-    reason = "La razón: bla bla bla.",
+    petName,
+    visible,
+    onClose,
+    reason = "La razón no fue especificada.",
 }: AdoptionRejectedModalProps) => {
-    const [visible, setVisible] = useState(false)
     const fadeAnim = new Animated.Value(0)
-
-    const close = () => setVisible(false)
+    const { user } = useAuthContext()
+    const role = user?.role
 
     useEffect(() => {
         Animated.timing(fadeAnim, {
@@ -22,41 +26,39 @@ const AdoptionRejectedModal = ({
             useNativeDriver: true,
         }).start()
     }, [visible])
+    
+    const showMessage = role === 20 || role === 21 || role === 22
 
     return (
-        <>
-            <Modal visible={visible} transparent animationType="fade" onRequestClose={close}>
-                <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
-                    <View style={styles.modalContainer}>
-                        <Image
-                            source={require("../../../assets/images/perro-gato.png")}
-                            style={styles.image}
-                        />
-                        <Text style={styles.title}>Solicitud Rechazada</Text>
-                        <Text style={styles.message}>
-                            Tu solicitud para{" "}
-                            <Text style={styles.boldText}>{petDetails.petName}</Text> ha sido
-                            rechazada.
-                        </Text>
-                        <Text style={styles.reason}>{reason}</Text>
-                        <View style={styles.buttonsContainer}>
-                            <Button title="Cerrar" onPress={close} color="#FF5733" />
-                        </View>
+        <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+            <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
+                <View style={styles.modalContainer}>
+                    <Image
+                        source={require("../../../assets/images/perro-gato.png")}
+                        style={styles.image}
+                    />
+                    <Text style={styles.title}>Solicitud Rechazada</Text>
+
+                    {showMessage && (
+                        <>
+                            <Text style={styles.message}>
+                                Tu solicitud para <Text style={styles.boldText}>{petName}</Text> ha
+                                sido rechazada.
+                            </Text>
+                            <Text style={styles.reason}>{reason}</Text>
+                        </>
+                    )}
+
+                    <View style={styles.buttonsContainer}>
+                        <Button title="Cerrar" onPress={onClose} color="#FF5733" />
                     </View>
-                </Animated.View>
-            </Modal>
-        </>
+                </View>
+            </Animated.View>
+        </Modal>
     )
 }
 
 const styles = StyleSheet.create({
-    testButton: {
-        backgroundColor: "#F44336",
-        padding: 10,
-        borderRadius: 8,
-        marginBottom: 20,
-        alignSelf: "center",
-    },
     modalBackground: {
         flex: 1,
         justifyContent: "center",

--- a/apps/mobile/components/common/modals/PendingRequestModal.tsx
+++ b/apps/mobile/components/common/modals/PendingRequestModal.tsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from "react"
 import { Modal, View, Text, Button, StyleSheet, Animated, Image } from "react-native"
+import { useAuthContext } from "@/context/AuthContext"
 
 type PendingRequestModalProps = {
-    petDetails: { petName: string }
+    petName: string
+    visible: boolean
+    onClose: () => void
 }
 
-const PendingRequestModal = ({ petDetails }: PendingRequestModalProps) => {
-    const [visible, setVisible] = useState(false)
+const PendingRequestModal = ({ petName, visible, onClose }: PendingRequestModalProps) => {
     const fadeAnim = new Animated.Value(0)
-
-    const close = () => setVisible(false)
+    const { user } = useAuthContext()
+    const role = user?.role
 
     useEffect(() => {
         Animated.timing(fadeAnim, {
@@ -19,39 +21,35 @@ const PendingRequestModal = ({ petDetails }: PendingRequestModalProps) => {
         }).start()
     }, [visible])
 
+    const showMessage = role === 20 || role === 21 || role === 22
+
     return (
-        <>
-            <Modal visible={visible} transparent animationType="fade" onRequestClose={close}>
-                <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
-                    <View style={styles.modalContainer}>
-                        <Image
-                            source={require("../../../assets/images/perro-gato.png")}
-                            style={styles.image}
-                        />
-                        <Text style={styles.title}>Solicitud Pendiente</Text>
+        <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+            <Animated.View style={[styles.modalBackground, { opacity: fadeAnim }]}>
+                <View style={styles.modalContainer}>
+                    <Image
+                        source={require("../../../assets/images/perro-gato.png")}
+                        style={styles.image}
+                    />
+                    <Text style={styles.title}>Solicitud Pendiente</Text>
+
+                    {showMessage && (
                         <Text style={styles.message}>
                             Tu solicitud para adoptar a{" "}
-                            <Text style={styles.boldText}>{petDetails.petName}</Text> está siendo
-                            revisada.
+                            <Text style={styles.boldText}>{petName}</Text> está siendo revisada.
                         </Text>
-                        <View style={styles.buttonsContainer}>
-                            <Button title="Cerrar" onPress={close} color="#FFC107" />
-                        </View>
+                    )}
+
+                    <View style={styles.buttonsContainer}>
+                        <Button title="Cerrar" onPress={onClose} color="#FFC107" />
                     </View>
-                </Animated.View>
-            </Modal>
-        </>
+                </View>
+            </Animated.View>
+        </Modal>
     )
 }
 
 const styles = StyleSheet.create({
-    testButton: {
-        backgroundColor: "#FFC107",
-        padding: 10,
-        borderRadius: 8,
-        marginBottom: 20,
-        alignSelf: "center",
-    },
     modalBackground: {
         flex: 1,
         justifyContent: "center",


### PR DESCRIPTION
- Se modificó la vista de detalle de solicitud de adopción (RequestDetailCard)   para mostrar información y acciones según el rol del usuario:   • Rol 20 (usuario): muestra solo el código de adopción al ser aceptada.   • Roles 21 y 22 (shelter y giver): muestra botones de aceptar/rechazar.   • Al aceptar, se habilita un input para ingresar el código del adoptante. - Se creó la vista de lista y detalle de solicitudes para (shelter). - Se actualizó la BottomNavbar para redirigir correctamente a las vistas de solicitudes. - Verificado en ejecución en Expo (funciones de aceptar/rechazar registran logs correctos).