### PR TITLE
fix: integrar botón Back en el header y ajustar comportamiento del menú

### DIFF
--- a/apps/mobile/app/(home)/_layout.tsx
+++ b/apps/mobile/app/(home)/_layout.tsx
@@ -1,40 +1,22 @@
 import React, { useState } from "react"
 import { StyleSheet } from "react-native"
-import { Slot, usePathname, Redirect } from "expo-router"
+import { Slot } from "expo-router"
 import Header from "@common/Header"
 import BottomNavbar from "@common/BottomNavbar"
-import BackButton from "@common/BackButton"
 import DropdownMenu from "@common/DropdownMenu"
 import { StatusBar } from "expo-status-bar"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { Colors } from "@/constants/Colors"
-import { useAuthContext } from "@/context/AuthContext"
 
 export default function HomeLayout() {
-    const pathname = usePathname()
     const [menuVisible, setMenuVisible] = useState(false)
-    // const { user } = useAuthContext()
-
-    // if (!user) return <Redirect href="/(auth)/login" />
-    // if (user.role !== 19) return <Redirect href="/(shelter)" />
-
-    const showBackButton = pathname !== "/"
-    let backButtonStyle = {}
-    if (pathname.includes("/my-profile")) {
-        backButtonStyle = { top: 135, left: 10 }
-    }
 
     return (
         <SafeAreaView style={styles.container}>
             <StatusBar style="inverted" />
-
             <Header onMenuPress={() => setMenuVisible(true)} />
             <Slot />
-
-            {showBackButton && <BackButton style={backButtonStyle} />}
-
             <BottomNavbar />
-
             {menuVisible && <DropdownMenu onClose={() => setMenuVisible(false)} />}
         </SafeAreaView>
     )
@@ -44,6 +26,5 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: Colors.yellow,
-        opacity: 1,
     },
 })

--- a/apps/mobile/components/common/BackButton.tsx
+++ b/apps/mobile/components/common/BackButton.tsx
@@ -7,20 +7,18 @@ const { width } = Dimensions.get("window")
 
 type BackButtonProps = {
     style?: StyleProp<ViewStyle>
+    floating?: boolean
 }
 
-export default function BackButton({ style }: BackButtonProps) {
+export default function BackButton({ style, floating = true }: BackButtonProps) {
     const router = useRouter()
 
     return (
         <TouchableOpacity
-            style={[styles.button, style]}
+            style={[floating ? styles.button : styles.inlineButton, style]}
             onPress={() => {
-                if (router.canGoBack()) {
-                    router.back()
-                } else {
-                    router.replace("/(home)")
-                }
+                if (router.canGoBack()) router.back()
+                else router.replace("/(home)")
             }}
         >
             <Ionicons name="arrow-back" size={width * 0.07} color="#000" />
@@ -31,8 +29,8 @@ export default function BackButton({ style }: BackButtonProps) {
 const styles = StyleSheet.create({
     button: {
         position: "absolute",
-        top: 135, 
-        left: 10, 
+        top: 135,
+        left: 10,
         backgroundColor: "#fff",
         borderRadius: width * 0.08,
         padding: width * 0.03,
@@ -42,5 +40,11 @@ const styles = StyleSheet.create({
         shadowRadius: 4,
         elevation: 4,
         zIndex: 10,
+    },
+    inlineButton: {
+        backgroundColor: "#fff",
+        borderRadius: width * 0.06,
+        padding: width * 0.02,
+        elevation: 3,
     },
 })

--- a/apps/mobile/components/common/Header.tsx
+++ b/apps/mobile/components/common/Header.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { View, TouchableOpacity, Image, StyleSheet, Dimensions, Text } from "react-native"
 import { Ionicons } from "@expo/vector-icons"
-import { useRouter } from "expo-router"
+import { useRouter, usePathname } from "expo-router"
 import { useAuthContext } from "@/context/AuthContext"
 import { Colors } from "@/constants/Colors"
+import BackButton from "@common/BackButton"
 
 const { width } = Dimensions.get("window")
 
@@ -13,6 +14,7 @@ type HeaderProps = {
 
 export default function Header({ onMenuPress }: HeaderProps) {
     const router = useRouter()
+    const pathname = usePathname().toLowerCase()
     const { user } = useAuthContext()
 
     const defaultAvatar = "https://randomuser.me/api/portraits/women/44.jpg"
@@ -26,23 +28,51 @@ export default function Header({ onMenuPress }: HeaderProps) {
         }
     }
 
+    // 🔙 Mostrar back solo en rutas que no sean home
+    const showBack =
+        pathname.includes("my-profile") ||
+        pathname.includes("request") ||
+        pathname.includes("detail") ||
+        pathname.includes("message")
+
     return (
         <View style={styles.container}>
-            <TouchableOpacity style={styles.iconButton} onPress={onMenuPress}>
-                <Ionicons name="menu" size={width * 0.07} color="#000" />
-            </TouchableOpacity>
-
-            <Image source={require("@/assets/images/Ayun-pet-Logo.png")} style={styles.logo} />
-
-            <TouchableOpacity style={styles.profileCircle} onPress={handleProfilePress}>
-                <Image source={{ uri: userAvatar }} style={styles.profileImage} />
-
-                {!user && (
-                    <View style={styles.noUserIndicator}>
-                        <Text style={styles.noUserText}>?</Text>
-                    </View>
+            {/* Izquierda: menú o back */}
+            <View style={styles.leftContainer}>
+                {showBack ? (
+                    <BackButton
+                        floating={false}
+                        style={{
+                            backgroundColor: "#fff",
+                            borderRadius: width * 0.06,
+                            padding: width * 0.02,
+                            elevation: 3,
+                            marginLeft: -4,
+                        }}
+                    />
+                ) : (
+                    <TouchableOpacity style={styles.iconButton} onPress={onMenuPress}>
+                        <Ionicons name="menu" size={width * 0.07} color="#000" />
+                    </TouchableOpacity>
                 )}
-            </TouchableOpacity>
+            </View>
+
+            {/* Centro: logo */}
+            <View style={styles.centerContainer}>
+                <Image source={require("@/assets/images/Ayun-pet-Logo.png")} style={styles.logo} />
+            </View>
+
+            {/* Derecha: perfil */}
+            <View style={styles.rightContainer}>
+                <TouchableOpacity style={styles.profileCircle} onPress={handleProfilePress}>
+                    <Image source={{ uri: userAvatar }} style={styles.profileImage} />
+                    {!user && (
+                        <View style={styles.noUserIndicator}>
+                            <Text style={styles.noUserText}>?</Text>
+                        </View>
+                    )}
+                </TouchableOpacity>
+            </View>
         </View>
     )
 }
@@ -56,6 +86,19 @@ const styles = StyleSheet.create({
         backgroundColor: Colors.yellow,
         paddingHorizontal: width * 0.05,
         paddingVertical: width * 0.02,
+    },
+    leftContainer: {
+        flex: 0.4, // menos espacio al back/menu
+        alignItems: "flex-start",
+    },
+    centerContainer: {
+        flex: 1.2, // más espacio para el logo
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    rightContainer: {
+        flex: 0.4,
+        alignItems: "flex-end",
     },
     iconButton: { padding: 5 },
     logo: {


### PR DESCRIPTION
Se eliminó el botón Back global del layout y se integró directamente dentro del header principal para mantener coherencia visual en todas las vistas. El botón ahora se muestra únicamente en pantallas internas (perfil, solicitudes, detalles, mensajes), mientras que el menú desplegable queda disponible solo en la vista principal (home), evitando superposición de elementos y mejorando la usabilidad general.