### PR TITLE
feat: corregir visualización de edad en detalle de publicación

### DIFF
--- a/apps/adoptions/src/controllers/publications.ts
+++ b/apps/adoptions/src/controllers/publications.ts
@@ -48,7 +48,23 @@ export const listPublications = async (req: AuthenticatedRequest, res: Response)
 
         let query = supabase
             .from("post")
-            .select("*, pet:pet_id(*)", { count: "exact" })
+            .select(
+                `
+        *,
+        pet:pet_id (
+            id,
+            name,
+            species,
+            gender,
+            size,
+            sterilized,
+            adopted,
+            age_years,
+            age_months
+        )
+    `,
+                { count: "exact" }
+            )
             .order("id", { ascending: true })
 
         if (ownerId !== undefined) query = query.eq("creator_id", ownerId)
@@ -112,9 +128,31 @@ export const getPublicationById = async (req: AuthenticatedRequest, res: Respons
         const id = parseId(req.params.id)
         const { data, error } = await supabase
             .from("post")
-            .select("*, pet:pet_id(*)")
+            .select(
+                `
+      id,
+      creator_id,
+      pet_id,
+      title,
+      description,
+      status,
+      created_at,
+      updated_at,
+      pet:pet_id (
+          id,
+          name,
+          species,
+          gender,
+          size,
+          sterilized,
+          adopted,
+          age_years,
+          age_months
+      )
+  `
+            )
             .eq("id", id)
-            .single()
+            .maybeSingle()
 
         if (error || !data) throw new AppError(404, "Publicación no encontrada")
 

--- a/apps/mobile/app/(home)/publication/[id].tsx
+++ b/apps/mobile/app/(home)/publication/[id].tsx
@@ -26,6 +26,7 @@ import { toMediaUrl } from "@/utils/mediaUrl"
 import { usePublicationContext } from "@/context/PublicationContext"
 import { useAdoptionRequestContext } from "@/context/AdoptionRequestContext"
 import type { PublicationItem } from "@/context/PublicationContext"
+import { translateSpeciesToSpanish, translateGenderToSpanish } from "@/utils/petTranslations"
 
 type MessageFormData = z.infer<typeof MessageFormSchema>
 
@@ -92,6 +93,30 @@ export default function PublicationDetail() {
         )
     }, [id, publications])
 
+    const formatAge = (age?: string | number | null) => {
+        // Si viene vacío o indefinido
+        if (!age || age === "undefined" || age === "null") return "Desconocida"
+
+        // Si viene como cadena no numérica
+        if (typeof age === "string") {
+            const numericAge = Number(age)
+            if (isNaN(numericAge)) {
+                // si la cadena no es número (ej: "Cachorro"), devuélvela tal cual
+                return age.trim().length > 0 ? age : "Desconocida"
+            }
+            age = numericAge
+        }
+
+        // A esta altura, age es número
+        if (typeof age === "number") {
+            if (age <= 0) return "Cachorro"
+            if (age === 1) return "1 año"
+            if (age > 1) return `${age} años`
+        }
+
+        return "Desconocida"
+    }
+
     const mapPublicationToPet = React.useCallback((pub: PublicationItem): Pet => {
         const imageSource =
             typeof pub.image === "string"
@@ -100,14 +125,35 @@ export default function PublicationDetail() {
                 ? { uri: (pub.image as any).uri }
                 : pub.image || { uri: "https://placehold.co/800x600?text=Mascota" }
 
+        // 🔹 Extraer años y meses si existen (ya sea en PublicationItem o si vienen del backend)
+        const years =
+            Number((pub as any).age_years ?? 0) ||
+            (typeof pub.age === "string" && pub.age.includes("año") ? parseInt(pub.age) : 0)
+        const months =
+            Number((pub as any).age_months ?? 0) ||
+            (typeof pub.age === "string" && pub.age.includes("mes") ? parseInt(pub.age) : 0)
+
+        // 🔹 Construir texto de edad consistente
+        const totalAge =
+            years > 0 && months > 0
+                ? `${years} ${years === 1 ? "año" : "años"} y ${months} ${
+                      months === 1 ? "mes" : "meses"
+                  }`
+                : years > 0
+                ? `${years} ${years === 1 ? "año" : "años"}`
+                : months > 0
+                ? `${months} ${months === 1 ? "mes" : "meses"}`
+                : "Desconocida"
+
         return {
             id: String(pub.postId ?? pub.id),
             name: pub.name ?? "Sin nombre",
             gender: pub.gender ?? "",
-            age: pub.age ?? "",
+            age: totalAge,
             publisher: pub.publisher ?? "Usuario",
             description: pub.description ?? "",
             image: imageSource,
+            type: pub.type ?? pub.species ?? "",
         }
     }, [])
 
@@ -130,10 +176,11 @@ export default function PublicationDetail() {
                             id,
                             name: raw.name,
                             gender: raw.gender,
-                            age: `${raw.ageYears} años`,
+                            age: raw.ageYears ? `${raw.ageYears} años` : "Desconocida", // 👈 corregido
                             publisher: raw.ownerName || "Yo",
                             description: raw.description ?? "",
                             image: { uri: url },
+                            type: raw.type || raw.species || "",
                         }
                         if (alive) setPet(petObj)
                     } else if (alive) {
@@ -302,10 +349,20 @@ export default function PublicationDetail() {
                             <View style={styles.infoRow}>
                                 <View style={styles.infoColumn}>
                                     <Text style={styles.infoLabel}>
-                                        Género: <Text style={styles.infoValue}>{pet.gender}</Text>
+                                        Especie:{" "}
+                                        <Text style={styles.infoValue}>
+                                            {translateSpeciesToSpanish((pet as any).type || "")}
+                                        </Text>
                                     </Text>
                                     <Text style={styles.infoLabel}>
-                                        Edad: <Text style={styles.infoValue}>{pet.age}</Text>
+                                        Género:{" "}
+                                        <Text style={styles.infoValue}>
+                                            {translateGenderToSpanish(pet.gender || "")}
+                                        </Text>
+                                    </Text>
+                                    <Text style={styles.infoLabel}>
+                                        Edad:{" "}
+                                        <Text style={styles.infoValue}>{formatAge(pet.age)}</Text>
                                     </Text>
                                 </View>
                                 <View style={styles.infoColumn}>

--- a/apps/mobile/components/common/PublicationCard.tsx
+++ b/apps/mobile/components/common/PublicationCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router"
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated"
 import { Pet } from "@/interfaces/pet"
 import { Colors } from "@/constants/Colors"
+import { translateSpeciesToSpanish, translateGenderToSpanish } from "@/utils/petTranslations"
 
 interface PublicationCardProps {
     pet: Pet
@@ -39,6 +40,16 @@ const PublicationCard: React.FC<PublicationCardProps> = ({ pet }) => {
         }
     })
 
+    const formatAge = (age?: string | number) => {
+        if (age === undefined || age === null || age === "" || age === "undefined")
+            return "Desconocida"
+        const numericAge = Number(age)
+        if (isNaN(numericAge)) return String(age)
+        if (numericAge <= 0) return "Cachorro"
+        if (numericAge === 1) return "1 año"
+        return `${numericAge} años`
+    }
+
     return (
         <Animated.View
             style={[styles.card, animatedStyle]}
@@ -53,7 +64,12 @@ const PublicationCard: React.FC<PublicationCardProps> = ({ pet }) => {
                 <Animated.Text style={styles.name} sharedTransitionTag={`pet-name-${pet.id}`}>
                     {pet.name}
                 </Animated.Text>
-                <Text style={styles.details}>{`${pet.gender} ${pet.age}`}</Text>
+                <Text style={styles.details}>
+                    {`${translateSpeciesToSpanish(
+                        (pet as any).type || ""
+                    )} • ${translateGenderToSpanish(pet.gender || "")} • ${formatAge(pet.age)}`}
+                </Text>
+
                 <Text style={styles.publisher}>Publicado por: {pet.publisher}</Text>
             </View>
             <TouchableOpacity

--- a/apps/mobile/context/PublicationContext.tsx
+++ b/apps/mobile/context/PublicationContext.tsx
@@ -85,15 +85,29 @@ export const PublicationProvider: React.FC<React.PropsWithChildren> = ({ childre
     const buildPublicationItem = React.useCallback((post: any, pet: any): PublicationItem => {
         const postImages: string[] = Array.isArray(post?.images) ? post.images : []
         const petImages: string[] = Array.isArray(pet?.images) ? pet.images : []
-
         const imageUri =
             postImages[0] || petImages[0] || "https://placehold.co/400x400?text=Mascota"
+
+        // Obtener edad combinada desde age_years y age_months
+        const years = Number(pet?.age_years ?? 0)
+        const months = Number(pet?.age_months ?? 0)
+
+        const ageText =
+            years > 0 && months > 0
+                ? `${years} ${years === 1 ? "año" : "años"} y ${months} ${
+                      months === 1 ? "mes" : "meses"
+                  }`
+                : years > 0
+                ? `${years} ${years === 1 ? "año" : "años"}`
+                : months > 0
+                ? `${months} ${months === 1 ? "mes" : "meses"}`
+                : "Desconocida"
 
         return {
             id: String(post?.id ?? ""),
             name: pet?.name || "Sin nombre",
             gender: pet?.gender ?? "",
-            age: typeof pet?.age === "number" ? `${pet.age} años` : "",
+            age: ageText,
             publisher: "Usuario",
             description: post?.description ?? "",
             image: { uri: imageUri },
@@ -114,6 +128,10 @@ export const PublicationProvider: React.FC<React.PropsWithChildren> = ({ childre
         }
     }, [status])
 
+    /**
+     * GET: Obtener todas las publicaciones disponibles
+     * Permite a todos los usuarios listar mascotas disponibles para adopción
+     */
     /**
      * GET: Obtener todas las publicaciones disponibles
      * Permite a todos los usuarios listar mascotas disponibles para adopción
@@ -146,7 +164,8 @@ export const PublicationProvider: React.FC<React.PropsWithChildren> = ({ childre
                             name: string | null
                             species: string
                             gender: string
-                            age: number
+                            age_years?: number | null
+                            age_months?: number | null
                             size: string
                             sterilized: boolean
                             adopted: boolean
@@ -164,27 +183,43 @@ export const PublicationProvider: React.FC<React.PropsWithChildren> = ({ childre
 
             // Transformar los datos de la API para el frontend
             const transformedPublications: PublicationItem[] = response.data.data.items.map(
-                (item) => ({
-                    id: String(item.post.id),
-                    name: item.pet.name || "Sin nombre",
-                    gender: item.pet.gender,
-                    age: `${item.pet.age} años`,
-                    publisher: "Usuario", // Por ahora no viene info del creador en la respuesta
-                    description: item.post.description,
-                    image:
-                        item.post.images && item.post.images.length > 0
-                            ? { uri: toMediaUrl(item.post.images[0]) }
-                            : item.pet.images && item.pet.images.length > 0
-                            ? { uri: toMediaUrl(item.pet.images[0]) }
-                            : { uri: "https://placehold.co/400x400?text=Mascota" },
-                    species: item.pet.species,
-                    size: item.pet.size,
-                    sterilized: item.pet.sterilized,
-                    status: item.post.status,
-                    postId: item.post.id,
-                    petId: item.pet.id,
-                    creatorId: item.post.creator_id,
-                })
+                (item) => {
+                    const years = Number(item.pet.age_years ?? 0)
+                    const months = Number(item.pet.age_months ?? 0)
+
+                    const age =
+                        years > 0 && months > 0
+                            ? `${years} ${years === 1 ? "año" : "años"} y ${months} ${
+                                  months === 1 ? "mes" : "meses"
+                              }`
+                            : years > 0
+                            ? `${years} ${years === 1 ? "año" : "años"}`
+                            : months > 0
+                            ? `${months} ${months === 1 ? "mes" : "meses"}`
+                            : "Desconocida"
+
+                    return {
+                        id: String(item.post.id),
+                        name: item.pet.name || "Sin nombre",
+                        gender: item.pet.gender,
+                        age,
+                        publisher: "Usuario", // Por ahora no viene info del creador en la respuesta
+                        description: item.post.description,
+                        image:
+                            item.post.images && item.post.images.length > 0
+                                ? { uri: toMediaUrl(item.post.images[0]) }
+                                : item.pet.images && item.pet.images.length > 0
+                                ? { uri: toMediaUrl(item.pet.images[0]) }
+                                : { uri: "https://placehold.co/400x400?text=Mascota" },
+                        species: item.pet.species,
+                        size: item.pet.size,
+                        sterilized: item.pet.sterilized,
+                        status: item.post.status,
+                        postId: item.post.id,
+                        petId: item.pet.id,
+                        creatorId: item.post.creator_id,
+                    }
+                }
             )
 
             setPublications(transformedPublications)
@@ -218,24 +253,57 @@ export const PublicationProvider: React.FC<React.PropsWithChildren> = ({ childre
                 }>(`/v1/adoptions/publications/${numericId}`)
 
                 const { post, pet } = response.data.data || {}
-                if (!post || !pet) {
-                    return null
+                if (!post || !pet) return null
+
+                // 🔹 Normalizar edad igual que en getPublications()
+                const years = Number(pet.age_years ?? 0)
+                const months = Number(pet.age_months ?? 0)
+
+                const age =
+                    years > 0 && months > 0
+                        ? `${years} ${years === 1 ? "año" : "años"} y ${months} ${
+                              months === 1 ? "mes" : "meses"
+                          }`
+                        : years > 0
+                        ? `${years} ${years === 1 ? "año" : "años"}`
+                        : months > 0
+                        ? `${months} ${months === 1 ? "mes" : "meses"}`
+                        : "Desconocida"
+
+                const mapped: PublicationItem = {
+                    id: String(post.id),
+                    name: pet.name || "Sin nombre",
+                    gender: pet.gender,
+                    age,
+                    publisher: "Usuario",
+                    description: post.description,
+                    image:
+                        post.images && post.images.length > 0
+                            ? { uri: toMediaUrl(post.images[0]) }
+                            : pet.images && pet.images.length > 0
+                            ? { uri: toMediaUrl(pet.images[0]) }
+                            : { uri: "https://placehold.co/400x400?text=Mascota" },
+                    species: pet.species,
+                    size: pet.size,
+                    sterilized: pet.sterilized,
+                    status: post.status,
+                    postId: post.id,
+                    petId: pet.id,
+                    creatorId: post.creator_id,
                 }
 
-                const mapped = buildPublicationItem(post, pet)
                 setPublications((prev) => {
-                    const hasPublication = prev.some(
-                        (pub) => Number(pub.postId ?? pub.id) === numericId
-                    )
-                    return hasPublication ? prev : [...prev, mapped]
+                    const exists = prev.some((pub) => Number(pub.postId ?? pub.id) === numericId)
+                    return exists ? prev : [...prev, mapped]
                 })
+
                 return mapped
             } catch (e: any) {
                 console.error("Error al obtener publicación por postId:", e)
                 return null
             }
         },
-        [buildPublicationItem, publications]
+        [publications]
     )
 
     /**

--- a/apps/mobile/utils/petTranslations.ts
+++ b/apps/mobile/utils/petTranslations.ts
@@ -59,6 +59,12 @@ export const translateSpeciestoBackend = (species: string): string => {
 }
 
 export const translateSpeciesToSpanish = (species: string): "Perro" | "Gato" | "Otro" => {
+    if (!species) return "Otro"
+
+    const normalized = species.trim().toLowerCase()
+    if (normalized === "dog") return "Perro"
+    if (normalized === "cat") return "Gato"
+
     const translation =
         SpeciesTranslations.toSpanish[species as keyof typeof SpeciesTranslations.toSpanish]
     return translation || "Otro"


### PR DESCRIPTION
Se corrige la lógica de mapeo de edad en la vista de detalle de publicaciones (PublicationDetail), ya que mostraba “Desconocida” pese a tener datos válidos en la base de datos.  - Se ajusta la función mapPublicationToPet para considerar correctamente los campos age_years y age_months. - Se unifica la lógica con la utilizada en getPublications() del PublicationContext. - Ahora las edades se muestran de forma coherente tanto en las tarjetas del home como en el detalle.  Resultado: el detalle de cada mascota refleja correctamente su edad (ej. “1 año”, “3 años y 2 meses”, etc.).