### PR TITLE
feat: ajustar lógica de bienvenida para mostrarse solo antes de login…

### DIFF
--- a/apps/mobile/app/(auth)/index.tsx
+++ b/apps/mobile/app/(auth)/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router"
 
 import { useAuthContext } from "@/context/AuthContext"
 import { isFirstLaunch, markFirstLaunch } from "@/utils/storage"
+import { hasSeenWelcome } from "@/utils/storage"
 
 export default function Index() {
     const router = useRouter()
@@ -12,11 +13,11 @@ export default function Index() {
 
     useEffect(() => {
         ;(async () => {
-            const first = await isFirstLaunch()
-
             if (status === "loading") return
-            if (first) {
-                await markFirstLaunch()
+
+            const seenWelcome = await hasSeenWelcome()
+
+            if (status === "unauthenticated" && !seenWelcome) {
                 router.replace("/(auth)/welcome")
                 return
             }
@@ -27,10 +28,11 @@ export default function Index() {
                 return
             }
 
-            if (status === "unauthenticated") {
+            if (status === "unauthenticated" && seenWelcome) {
                 router.replace("/(auth)/(login)/")
                 return
             }
+
             setChecking(false)
         })()
     }, [status, user])

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -4,20 +4,24 @@ import { useRouter } from "expo-router"
 import { Colors } from "@/constants/Colors"
 import { useAuthContext, User } from "@/context/AuthContext"
 import Ionicons from "@expo/vector-icons/Ionicons"
+import { setWelcomeSeen } from "@/utils/storage"
 
 const Welcome = () => {
     const { height } = useWindowDimensions()
     const router = useRouter()
 
-    const handleLoginPress = () => {
+    const handleLoginPress = async () => {
+        await setWelcomeSeen()
         router.push("/(auth)/(login)/")
     }
 
-    const handleUserPress = () => {
+    const handleUserPress = async () => {
+        await setWelcomeSeen()
         router.push("/(auth)/(register)/user")
     }
 
-    const handleGiverPress = () => {
+    const handleGiverPress = async () => {
+        await setWelcomeSeen()
         router.push("/(auth)/(register)/giver")
     }
 

--- a/apps/mobile/utils/storage.ts
+++ b/apps/mobile/utils/storage.ts
@@ -68,3 +68,21 @@ export async function savePlainPassword(password: string) {
 export async function getPlainPassword() {
     return await SecureStore.getItemAsync("plainPassword")
 }
+
+export async function hasSeenWelcome(): Promise<boolean> {
+    try {
+        const value = await AsyncStorage.getItem("first_launch")
+        return value === "done"
+    } catch (e) {
+        console.error("Error leyendo flag de welcome:", e)
+        return false
+    }
+}
+
+export async function setWelcomeSeen() {
+    try {
+        await AsyncStorage.setItem("first_launch", "done")
+    } catch (e) {
+        console.error("Error guardando flag de welcome:", e)
+    }
+}


### PR DESCRIPTION
… o registro

Se modificó la lógica del flujo de bienvenida (Welcome) para que solo se muestre una vez antes del inicio de sesión o registro.  Ahora el flag de primera ejecución se maneja mediante AsyncStorage y se marca automáticamente al salir del welcome,  permitiendo que el usuario vea esta vista únicamente si no ha iniciado sesión y nunca la ha visto antes.  Se actualizó la verificación en (auth)/index.tsx y se implementó el guardado del flag en welcome.tsx sin alterar otros flujos de autenticación.