### PR TITLE
fix: evitar recarga de la aplicación tras inicio de sesión

### DIFF
--- a/apps/mobile/components/common/Header.tsx
+++ b/apps/mobile/components/common/Header.tsx
@@ -14,7 +14,6 @@ import { useAuthContext } from "@/context/AuthContext"
 import { Colors } from "@/constants/Colors" // 2. Importar { Colors }
 import BackButton from "@common/BackButton"
 import { userService } from "@/services/user"
-import { getProfilePictureUrl } from "@/utils/profilePicture"
 
 const { width } = Dimensions.get("window")
 
@@ -34,17 +33,29 @@ export default function Header({ onMenuPress }: HeaderProps) {
 
     // Placeholder local para foto de perfil
     const placeholderImage = require("@images/pp_placeholder.png")
-    
+
     // Cargar foto de perfil cuando el usuario cambie
     useEffect(() => {
+        let mounted = true
+
         const loadProfilePicture = async () => {
-            if (user?.id) {
+            if (!user?.id) return
+            try {
                 const url = await userService.getProfilePicture(user.id)
-                setProfilePictureUrl(url)
+
+                // 🔒 Evitar actualizar si el valor no cambió o el componente ya se desmontó
+                if (!mounted) return
+                setProfilePictureUrl((prev) => (prev === url ? prev : url))
+            } catch (error) {
+                console.log(`No profile picture found for user ${user?.id}`)
+                if (mounted) setProfilePictureUrl(null)
             }
         }
-        
+
         loadProfilePicture()
+        return () => {
+            mounted = false
+        }
     }, [user?.id])
 
     // Determinar qué imagen mostrar
@@ -160,7 +171,6 @@ const styles = StyleSheet.create({
         height: width * 0.12,
         borderRadius: (width * 0.12) / 2,
         overflow: "hidden",
-        // backgroundColor: "#e60000ff", // <-- Quitado (fallback rojo)
         alignItems: "center",
         justifyContent: "center",
     },

--- a/apps/mobile/features/AuthRedirect.tsx
+++ b/apps/mobile/features/AuthRedirect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 import { useRouter, useSegments } from "expo-router"
 import { useAuthContext } from "@/context/AuthContext"
 
@@ -10,27 +10,24 @@ export default function AuthRedirect() {
 
     useEffect(() => {
         if (status === "loading") return
-        redirected.current = false  
+        if (!user) return
 
         const currentPath = `/${segments.join("/")}`
-        const inPrivateGroup = segments[0] === "(home)" || segments[0] === "(shelter)"
+        const firstSegment = segments[0]
+        const inPrivateGroup = firstSegment === "(home)" || firstSegment === "(shelter)"
+        const isGiverOrShelter = user.role === 21 || user.role === 22
+        const correctGroup = isGiverOrShelter ? "(shelter)" : "(home)"
 
-        if (status === "authenticated" && user) {
-            // Role 21 y 22 son givers/shelter, van a (shelter)
-            // Role 19 y 20 son admin/user, van a (home)
-            const isGiverOrShelter = user.role === 21 || user.role === 22
-            const isInCorrectGroup =
-                (isGiverOrShelter && segments[0] === "(shelter)") ||
-                (!isGiverOrShelter && segments[0] === "(home)")
-
-            if (!isInCorrectGroup && !redirected.current) {
+        // Solo redirigir si está autenticado y en un grupo incorrecto
+        if (status === "authenticated" && inPrivateGroup) {
+            if (firstSegment !== correctGroup && !redirected.current) {
                 redirected.current = true
                 router.replace(isGiverOrShelter ? "/(shelter)" : "/(home)")
             }
-
             return
         }
 
+        // Si no está autenticado y está en una ruta privada
         if (status === "unauthenticated" && inPrivateGroup) {
             const target = "/(auth)/(login)/"
             if (!redirected.current && currentPath !== target) {


### PR DESCRIPTION
Se corrige el problema que provocaba una recarga automática de la aplicación al iniciar sesión, principalmente en usuarios con rol de dador (21). El error ocurría debido a una redirección redundante en AuthRedirect que ocasionaba el remonte completo del layout y la ejecución duplicada del Header. Se actualiza AuthRedirect para validar el grupo actual antes de redirigir, evitando el replace innecesario. Además, se ajusta el Header para manejar la carga de foto de perfil de forma segura y sin re-renders innecesarios cuando no se encuentra una imagen (404).