### PR TITLE
fix: corregir flujo persistente de Welcome según autenticación real d…

### DIFF
--- a/apps/mobile/context/AuthContext.tsx
+++ b/apps/mobile/context/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/utils/storage"
 import { useRouter } from "expo-router"
 import { DeviceEventEmitter } from "react-native"
+import { saveHasCompletedAuth, clearHasCompletedAuth, getHasCompletedAuth } from "@/utils/storage"
 
 type Role = 19 | 20 | 21 | 22
 
@@ -68,6 +69,7 @@ interface AuthContextType {
     status: Status
     user: User | null
     token: string | null
+    hasCompletedAuth: boolean
     signIn: (data: LoginPayload) => Promise<void>
     signUp: (
         data: RegisterPayload,
@@ -82,15 +84,22 @@ const AuthContext = createContext<AuthContextType | null>(null)
 export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
     const [status, setStatus] = useState<Status>("loading")
     const [user, setUser] = useState<User | null>(null)
+    const [hasCompletedAuth, setHasCompletedAuthState] = useState<boolean>(false)
     const [token, setTokenState] = useState<string | null>(null)
     const router = useRouter()
 
     useEffect(() => {
         ;(async () => {
             try {
-                const [storedToken, storedUser] = await Promise.all([getToken(), getUser<User>()])
+                const [storedToken, storedUser, completed] = await Promise.all([
+                    getToken(),
+                    getUser<User>(),
+                    getHasCompletedAuth(),
+                ])
 
-                if (!storedUser) throw new Error("No user")
+                setHasCompletedAuthState(completed)
+
+                if (!storedUser) throw new Error("No user stored")
 
                 setUser(storedUser)
 
@@ -146,6 +155,10 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             }
 
             await afterAuthSuccess(token, userFormatted)
+
+            await saveHasCompletedAuth(true)
+            setHasCompletedAuthState(true)
+
             await savePlainPassword(data.password)
         } catch (e) {
             console.error("Error al iniciar sesión:", e)
@@ -167,9 +180,15 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
                 setStatus("unauthenticated")
             }
 
-            // Los roles giver (22) y shelter (21) no requieren verificación por email
-            // Los roles user (20) sí requieren verificación
             const requiresEmailVerification = variation === "user"
+
+            if (variation === "giver" || variation === "shelter") {
+                await saveHasCompletedAuth(true)
+                setHasCompletedAuthState(true)
+            } else {
+                await saveHasCompletedAuth(false)
+                setHasCompletedAuthState(false)
+            }
 
             return {
                 requiresEmailVerification,
@@ -189,6 +208,12 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     async function signOut(full: boolean = false) {
         if (full) await clearFull()
         else await clearDown()
+
+        if (full) {
+            await clearHasCompletedAuth()
+            setHasCompletedAuthState(false)
+        }
+
         router.replace("/(auth)/(login)/")
         setStatus("unauthenticated")
     }
@@ -209,11 +234,11 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
 
     async function clearFull() {
         await clearAuth()
+        await clearHasCompletedAuth()
         setAuthToken(null)
         setTokenState(null)
         setUser(null)
 
-        // Limpiar el estado del push token guardado
         try {
             const { clearPushTokenSaved } = await import("@/services/pushTokenService")
             await clearPushTokenSaved()
@@ -235,12 +260,13 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
             status,
             user,
             token,
+            hasCompletedAuth,
             signIn,
             signUp,
             signOut,
             updateUser,
         }),
-        [status, user, token, signIn, signUp, signOut, updateUser]
+        [status, user, token, hasCompletedAuth]
     )
 
     return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/apps/mobile/features/AuthRedirect.tsx
+++ b/apps/mobile/features/AuthRedirect.tsx
@@ -5,37 +5,80 @@ import { useAuthContext } from "@/context/AuthContext"
 export default function AuthRedirect() {
     const router = useRouter()
     const segments = useSegments()
-    const { status, user } = useAuthContext()
+    const { status, user, hasCompletedAuth } = useAuthContext()
     const redirected = useRef(false)
 
     useEffect(() => {
         if (status === "loading") return
-        if (!user) return
 
-        const currentPath = `/${segments.join("/")}`
-        const firstSegment = segments[0]
-        const inPrivateGroup = firstSegment === "(home)" || firstSegment === "(shelter)"
-        const isGiverOrShelter = user.role === 21 || user.role === 22
-        const correctGroup = isGiverOrShelter ? "(shelter)" : "(home)"
+        const root = segments[0] // "(auth)" | "(home)" | etc.
+        const child = segments[1]?.toLowerCase() // "(login)" | "(register)" | "welcome"
+        const sub = segments[2]?.toLowerCase() // "user" | "giver" | etc.
 
-        // Solo redirigir si está autenticado y en un grupo incorrecto
-        if (status === "authenticated" && inPrivateGroup) {
-            if (firstSegment !== correctGroup && !redirected.current) {
+        const isPrivate = root === "(home)" || root === "(shelter)"
+        const isAuthArea = root === "(auth)"
+
+        const isInsideRegister = child === "(register)"
+        const isInsideLogin = child === "(login)"
+        const isWelcome = child === "welcome"
+        const isPassword = child === "(password)"
+        const isVerifyEmail = child === "verify-email"
+        const isRegistrationSuccess = child === "registration-success"
+
+        const allowedBeforeAuth = [
+            "welcome",
+            "(login)",
+            "(register)",
+            "(password)",
+            "verify-email",
+            "registration-success",
+        ]
+
+        const allowUnauth =
+            allowedBeforeAuth.includes(child ?? "") || isInsideRegister || isInsideLogin
+
+        // ============================================================
+        // 1) AUTENTICADO → mandar al grupo correspondiente
+        // ============================================================
+        if (status === "authenticated" && user) {
+            const isGiverOrShelter = user.role === 21 || user.role === 22
+            const correctGroup = isGiverOrShelter ? "(shelter)" : "(home)"
+
+            if (root !== correctGroup && !redirected.current) {
                 redirected.current = true
                 router.replace(isGiverOrShelter ? "/(shelter)" : "/(home)")
             }
             return
         }
 
-        // Si no está autenticado y está en una ruta privada
-        if (status === "unauthenticated" && inPrivateGroup) {
-            const target = "/(auth)/(login)/"
-            if (!redirected.current && currentPath !== target) {
+        // ============================================================
+        // 2) NO AUTENTICADO → lógica welcome
+        // ============================================================
+        if (status === "unauthenticated") {
+            // --- Nunca completó → solo permitir rutas del auth flow
+            if (!hasCompletedAuth) {
+                if (!allowUnauth && !redirected.current) {
+                    redirected.current = true
+                    router.replace("/(auth)/welcome")
+                }
+                return
+            }
+
+            // --- Sí completó → NO debe ver Welcome jamás
+            if (isWelcome && !redirected.current) {
                 redirected.current = true
-                router.replace(target)
+                router.replace("/(auth)/(login)/")
+                return
+            }
+
+            // --- Sí completó → pero sin sesión → bloquear rutas privadas
+            if (isPrivate && !redirected.current) {
+                redirected.current = true
+                router.replace("/(auth)/(login)/")
+                return
             }
         }
-    }, [status, user, segments])
+    }, [status, user, segments, hasCompletedAuth])
 
     return null
 }

--- a/apps/mobile/utils/storage.ts
+++ b/apps/mobile/utils/storage.ts
@@ -68,3 +68,31 @@ export async function savePlainPassword(password: string) {
 export async function getPlainPassword() {
     return await SecureStore.getItemAsync("plainPassword")
 }
+
+const HAS_COMPLETED_AUTH_KEY = "@ayun/has_completed_auth"
+
+export async function saveHasCompletedAuth(value: boolean) {
+    try {
+        await AsyncStorage.setItem(HAS_COMPLETED_AUTH_KEY, value ? "true" : "false")
+    } catch (e) {
+        console.error("Error saving hasCompletedAuth", e)
+    }
+}
+
+export async function getHasCompletedAuth(): Promise<boolean> {
+    try {
+        const stored = await AsyncStorage.getItem(HAS_COMPLETED_AUTH_KEY)
+        return stored === "true"
+    } catch (e) {
+        console.error("Error getting hasCompletedAuth", e)
+        return false
+    }
+}
+
+export async function clearHasCompletedAuth() {
+    try {
+        await AsyncStorage.removeItem(HAS_COMPLETED_AUTH_KEY)
+    } catch (e) {
+        console.error("Error clearing hasCompletedAuth", e)
+    }
+}


### PR DESCRIPTION
…el usuario

Implementado flujo correcto para mostrar la vista Welcome solo cuando el usuario   no ha completado un proceso real de autenticación (login o registro exitoso). - Agregado flag persistente @ayun/has_completed_auth para evitar colisiones con Expo Router   y garantizar almacenamiento estable entre sesiones. - Actualizada lógica de AuthRedirect para:     • permitir rutas dentro de (auth) durante onboarding,     • bloquear acceso a áreas privadas sin sesión válida,     • evitar bucles de navegación hacia Welcome,     • impedir acceso a Welcome una vez completado el proceso de autenticación real. - Ajustado signIn, signUp y signOut para sincronizar correctamente el flag de completion. - Corregidos casos donde la app mostraba Welcome luego de cerrar sesión o reiniciar. - Se asegura experiencia consistente en primera apertura, registro, login y logout.