### PR TITLE
fix: solucionar recarga automática después de iniciar sesión

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -44,6 +44,9 @@ function RootLayoutNav() {
     return (
         <LoadingProvider>
             <AuthProvider>
+                {/* ✔️ AuthRedirect colocado JUSTO después del AuthProvider */}
+                <AuthRedirect />
+
                 <AlertProvider>
                     <ModalProvider>
                         <QuestionProvider>
@@ -76,7 +79,6 @@ function RootLayoutNav() {
 
                                                                 <ModalHost />
                                                                 <Alert />
-                                                                <AuthRedirect />
                                                                 <StatusBar style="auto" />
                                                             </NavThemeProvider>
                                                         </LoadingHandlerBridge>

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect } from "react"
 import { View, Image, Alert, BackHandler, Text } from "react-native"
 import LottieView from "lottie-react-native"
-import { Ionicons } from "@expo/vector-icons"
 import NetInfo from "@react-native-community/netinfo"
-import { useRouter } from "expo-router"
 import { Colors } from "@/constants/Colors"
 
 export default function Index() {
-    const router = useRouter()
-
     useEffect(() => {
+        // Mantener solo la validación de conexión
         checkConnection()
     }, [])
 
@@ -28,9 +25,10 @@ export default function Index() {
                 return showNoInternet()
             }
 
-            setTimeout(() => {
-                router.replace("/(auth)")
-            }, 5000)
+            // 👉 IMPORTANTE:
+            // YA NO HACEMOS router.replace("/(auth)")
+            // AuthRedirect es quien redirige automáticamente
+            // según el estado de autenticación.
         } catch {
             showNoInternet()
         }


### PR DESCRIPTION
Se eliminó la navegación tardía en app/index.tsx que realizaba un router.replace("/(auth)") después de 5 segundos, lo que provocaba una redirección inesperada incluso con la sesión iniciada.  Ahora el index actúa solo como pantalla de carga y la lógica de navegación inicial queda completamente delegada a AuthRedirect, evitando recargas automáticas y comportamientos inesperados al ingresar al home.